### PR TITLE
docs: accept backend-first FXH withdrawal orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,11 @@ out/
 # Ignores development broadcast logs
 broadcast/
 
-# Docs
-docs/
+# Generated docs
+docs/*
+!docs/adr/
+docs/adr/*
+!docs/adr/*.md
 
 # Dotenv file
 .env

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -9,6 +9,8 @@
 
 `VaultV2` serves ordinary ERC-4626 withdrawals synchronously. Its exit path uses idle EURC first and then asks the configured liquidity adapter to deallocate the shortfall. If the adapter cannot provide enough idle EURC, the transaction reverts.
 
+The July 8 discussion described Aave as the single liquid adapter holding roughly 10% of vault liquidity and the FXH adapter holding roughly 85%. Those percentages and assignments are deployment observations, not source-code defaults. Phase 0 must verify the live configuration before using them for routing or sizing.
+
 `ByzantineEurVaultAdapter` already provides the asynchronous path needed to recover liquidity from the FX hedge vault:
 
 1. its `adapterCurator` calls `requestWithdraw`;
@@ -31,6 +33,22 @@ The first proposed architecture replaced all exits with a new on-chain share esc
 
 The July 8 product discussion described a backend queue rather than a replacement withdrawal protocol. We therefore need the smallest reversible implementation that tests the actual operational assumptions without imposing a hot-path regression.
 
+### Transcript requirement mapping
+
+| Problem or request raised on July 8 | ADR treatment |
+|---|---|
+| A withdrawal larger than Aave/idle liquidity reverts and scares the customer | Intercept only the positively identified simulation failure and return an explicit queued outcome instead of broadcasting a reverting transaction. |
+| Smaller liquid withdrawals should continue immediately | Preserve the existing liquid hot path without new contract calls or queue work. |
+| Store the withdrawal request and customer signature in the database | Persist the exact customer-authorized transaction plus durable queue state; prove delayed validity before acceptance. |
+| Notify the team when a withdrawal queues | Require Telegram operator notification on queue entry and material state/failure transitions; email may be added but is not required for the canary. |
+| Call FXH adapter `requestWithdraw` through `adapterCurator` | Request bounded bpEUR shares through the approved curator custody path. |
+| Wait roughly 24 hours for the async FXH flow | Reconcile actual chain state; treat 24 hours as an expectation, not an SLA. |
+| Return EURC and automatically broadcast the stored customer withdrawal | After the human-authorized protocol steps complete, sweep the position, explicitly deallocate FXH-adapter EURC into `VaultV2` when required, re-simulate, and automatically broadcast the unchanged transaction once. |
+| Complete to either wallet or bank account | Resume the exact receiver/off-ramp path encoded by the original customer transaction; the queue must not substitute a destination. |
+| Consider rebalancing after a large withdrawal | Defer rebalancing to a separate decision. |
+| Propose a solution before implementation | Keep this ADR `Proposed` until the controlled integration evidence and operational decisions are approved. |
+| Store the curator key in application environment configuration | Intentionally rejected: use existing human-authorized custody first; constrained automation requires a separate decision; plaintext production keys are prohibited. |
+
 ## Decision
 
 Start with a **bounded backend-first canary**. Do not modify `VaultV2`, `ByzantineEurVaultAdapter`, `EurVaultPosition`, or `ByzantinePrimeEURVault` for v1.
@@ -40,15 +58,17 @@ The canary will:
 1. preserve the existing immediate-withdrawal path unchanged;
 2. enqueue only a positively identified, allowlisted liquidity-shortfall revert from simulation; all gate, authorization, balance, allowance, deadline, and unknown failures remain on the normal failure path;
 3. persist the exact customer-authorized withdrawal transaction and a durable queue record;
-4. permit at most one active queued withdrawal per vault and chain;
-5. request a bounded number of bpEUR shares from the FXH adapter through the approved `adapterCurator` custody path;
-6. derive progress from contract state and receipts rather than a fixed delay;
-7. observe or invoke `sweepSettled` after the FXH position settles, using a funded and monitored sender when invocation is required;
-8. unless the FXH adapter is the configured `liquidityAdapter`, have an approved allocator or sentinel call `VaultV2.deallocate` for that adapter to move the realized EURC into parent-vault idle;
-9. verify the actual parent-vault idle EURC produced by that deallocation;
-10. re-simulate the exact customer transaction immediately before broadcast;
-11. broadcast it at most once when simulation succeeds; and
-12. otherwise enter an explicit terminal or operator-review state.
+4. return a durable queue identifier and explicit queued status to the caller instead of surfacing the simulated liquidity revert;
+5. notify operators through Telegram when a request queues and on material intervention or terminal transitions;
+6. permit at most one active queued withdrawal per vault and chain;
+7. request a bounded number of bpEUR shares from the FXH adapter through the approved `adapterCurator` custody path;
+8. derive progress from contract state and receipts rather than a fixed delay;
+9. observe or invoke `sweepSettled` after the FXH position settles, using a funded and monitored sender when invocation is required;
+10. unless the FXH adapter is the configured `liquidityAdapter`, have an approved allocator or sentinel call `VaultV2.deallocate` for that adapter to move the realized EURC into parent-vault idle;
+11. verify the actual parent-vault idle EURC produced by that deallocation;
+12. re-simulate the exact customer transaction immediately before broadcast;
+13. broadcast it at most once when simulation succeeds; and
+14. otherwise enter an explicit terminal or operator-review state.
 
 This is **best-effort orchestration**, not an on-chain reservation system. It does not guarantee FIFO fairness, exclusive access to returned liquidity, a fixed settlement time, or successful execution of a transaction whose state has changed while queued.
 
@@ -146,6 +166,16 @@ failed
 
 No state may retry indefinitely. Every transaction submission must have an idempotency key, recorded hash/nonce, bounded attempt count, receipt reconciliation, and an operator-visible reason for stopping.
 
+### Customer, destination, and operator visibility
+
+A queued API response must contain a stable queue identifier and a queryable status; it must not expose the internal simulation revert as the customer-facing outcome. The status remains pending until the customer withdrawal is confirmed on chain.
+
+The original customer-authorized transaction remains authoritative for amount, receiver, and wallet-versus-off-ramp destination. Queue processing must not replace that destination. For a bank withdrawal, the queue hands control back to the existing off-ramp lifecycle after the on-chain withdrawal transaction is confirmed; bank settlement status remains a downstream concern and must not be conflated with FXH liquidity settlement.
+
+Telegram notification is required at queue entry, when human authorization is needed, when pending age crosses the approved operational threshold, when re-signing or operator review is required, and on confirmed or failed completion. Notifications are observational only: database and chain state remain authoritative, and duplicate delivery must not change queue state.
+
+The transcript's end-state aspiration is automatic completion without further customer action. The canary provides that only when delayed customer authorization remains valid. It intentionally retains human authorization for privileged curator and parent-vault deallocation calls until a separate custody decision approves automation.
+
 ### No rebalancing in v1
 
 Restoring target allocations after an FXH unwind is a separate risk and strategy decision. It is explicitly out of scope for this ADR.
@@ -198,6 +228,9 @@ The target chain, deployed addresses, source revisions, roles, gates, token deci
 - Submission is idempotent and bounded.
 - Failure and intervention states are explicit.
 - Canary exposure is bounded by cohort, notional, active-request count, retry count, and pending age.
+- The caller receives a durable queue identifier and queryable status for a recognized liquidity shortfall.
+- Operators receive Telegram notifications for queue entry, intervention thresholds, and terminal outcomes.
+- The original customer-selected wallet or off-ramp destination is preserved.
 
 ## What v1 Does Not Guarantee
 
@@ -210,6 +243,8 @@ The target chain, deployed addresses, source revisions, roles, gates, token deci
 
 These limitations must be present in product and operational language. The system must not describe a queued request as guaranteed or completed before the customer withdrawal is confirmed on chain.
 
+The canary also does not guarantee fully unattended completion: privileged protocol calls remain human-authorized until a separate custody decision approves constrained automation.
+
 ## Stop and Escalation Conditions
 
 Stop the canary and review the contract-enforced queue design if any of the following occurs:
@@ -219,8 +254,10 @@ Stop the canary and review the contract-enforced queue design if any of the foll
 3. delayed transactions require re-signing at an unacceptable rate;
 4. queued notional exceeds the approved operational risk cap;
 5. integrators require a composable on-chain claim or transferable withdrawal receipt;
-6. product or risk requires guaranteed FIFO/pro-rata reservation; or
-7. manual protocol authorization becomes an operational bottleneck and no acceptable constrained-signer design is approved.
+6. product or risk requires guaranteed FIFO/pro-rata reservation;
+7. manual protocol authorization becomes an operational bottleneck and no acceptable constrained-signer design is approved;
+8. customer or operator evidence shows that queued-response or notification semantics are inadequate; or
+9. end-to-end unattended completion becomes a hard requirement and an acceptable constrained-signer design is approved.
 
 A contract-first follow-up must be a separate ADR. It must define custody, cancellation, partial settlement, allocator interaction, reservation accounting, migration, standard-interface compatibility, and emergency behavior before implementation.
 
@@ -259,6 +296,8 @@ A contract-first follow-up must be a separate ADR. It must define custody, cance
 - Only one active illiquid request is supported per vault and chain.
 - Some customers may need to re-sign or retry.
 - The backend requires durable queue storage, reconciliation, monitoring, and runbooks.
+- The first canary is not fully unattended because privileged protocol operations remain human-authorized.
+- Telegram notification and a queryable queued response become required operational surfaces.
 
 ### Neutral
 
@@ -280,8 +319,12 @@ Before changing this ADR to `Accepted`, reviewers must approve:
 - allocator/sentinel and sweep-sender custody, funding, and monitoring;
 - bpEUR unwind-sizing bounds and realized-EURC reconciliation;
 - deployment metadata and finality policy;
-- controlled integration-test evidence; and
-- operational ownership and stop authority for the canary.
+- controlled integration-test evidence;
+- operational ownership and stop authority for the canary;
+- the queued API response contract and status-query surface;
+- Telegram notification recipients, deduplication, and escalation thresholds;
+- preservation of wallet/off-ramp destination and handoff to existing downstream tracking; and
+- whether human-authorized privileged calls satisfy the canary or automation is a release requirement.
 
 ## References
 

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -2,329 +2,204 @@
 
 - **Status:** Proposed
 - **Date:** 2026-07-14
-- **Decision owners:** Vault, FXH, API, Product, Security, and Operations maintainers
-- **Scope:** EUR vault withdrawals that cannot be satisfied immediately by the configured liquidity adapter
+- **Owners:** Vault, FXH, API, Product, Security, and Operations maintainers
+- **Scope:** EUR vault withdrawals that exceed immediately available liquidity
 
 ## Context
 
-`VaultV2` serves ordinary ERC-4626 withdrawals synchronously. Its exit path uses idle EURC first and then asks the configured liquidity adapter to deallocate the shortfall. If the adapter cannot provide enough idle EURC, the transaction reverts.
+`VaultV2` serves withdrawals synchronously. It uses idle EURC first, then asks its configured liquidity adapter for the shortfall. If the adapter cannot provide enough EURC, the transaction reverts.
 
-The July 8 discussion described Aave as the single liquid adapter holding roughly 10% of vault liquidity and the FXH adapter holding roughly 85%. Those percentages and assignments are deployment observations, not source-code defaults. Phase 0 must verify the live configuration before using them for routing or sizing.
+The July 8 discussion described Aave as the liquid adapter holding roughly 10% of vault assets and the FXH adapter holding roughly 85%. These are deployment observations, not source defaults. We must verify the live configuration before implementation.
 
-`ByzantineEurVaultAdapter` already provides the asynchronous path needed to recover liquidity from the FX hedge vault:
+Liquidity can return from FXH through the existing contracts:
 
-1. its `adapterCurator` calls `requestWithdraw`;
-2. the adapter creates or reuses an `EurVaultPosition` for the active FXH batch;
-3. the position requests withdrawal from `ByzantinePrimeEURVault`;
-4. FXH settlement completes through its keeper-driven daily net transfer process;
-5. `sweepSettled` returns realized EURC to the FXH adapter;
-6. unless the FXH adapter is itself the configured `liquidityAdapter`, an authorized `VaultV2` allocator or sentinel must call `VaultV2.deallocate` for the FXH adapter to pull that EURC into parent-vault idle; and
-7. only then can a later standard `VaultV2` exit consume the returned EURC.
+1. `adapterCurator` calls `ByzantineEurVaultAdapter.requestWithdraw` with bpEUR shares.
+2. FXH processes the request through its keeper-driven daily net transfer.
+3. `sweepSettled` moves realized EURC to `ByzantineEurVaultAdapter`.
+4. If FXH is not the configured liquidity adapter, an authorized allocator or sentinel calls `VaultV2.deallocate` to move the EURC into parent-vault idle.
+5. The original customer withdrawal can then execute.
 
-The current customer experience exposes the synchronous failure. The desired experience is to preserve the normal fast withdrawal path and coordinate the asynchronous path when liquidity is unavailable.
-
-The first proposed architecture replaced all exits with a new on-chain share escrow, reservation queue, and exclusive withdrawal gateway. That architecture would provide stronger fairness and reservation guarantees, but it would also:
-
-- change standard ERC-4626 withdrawal behavior and integrations;
-- add calls, transfers, storage writes, and gas to every withdrawal;
-- couple queue accounting to `VaultV2`, adapter positions, FXH batch settlement, allocator actions, and haircut behavior;
-- require a protocol migration, role changes, and a dedicated audit; and
-- solve concurrency and fairness requirements that have not yet been demonstrated by production evidence.
-
-The July 8 product discussion described a backend queue rather than a replacement withdrawal protocol. We therefore need the smallest reversible implementation that tests the actual operational assumptions without imposing a hot-path regression.
-
-### Transcript requirement mapping
-
-| Problem or request raised on July 8 | ADR treatment |
-|---|---|
-| A withdrawal larger than Aave/idle liquidity reverts and scares the customer | Intercept only the positively identified simulation failure and return an explicit queued outcome instead of broadcasting a reverting transaction. |
-| Smaller liquid withdrawals should continue immediately | Preserve the existing liquid hot path without new contract calls or queue work. |
-| Store the withdrawal request and customer signature in the database | Persist the exact customer-authorized transaction plus durable queue state; prove delayed validity before acceptance. |
-| Notify the team when a withdrawal queues | Require Telegram operator notification on queue entry and material state/failure transitions; email may be added but is not required for the canary. |
-| Call FXH adapter `requestWithdraw` through `adapterCurator` | Request bounded bpEUR shares through the approved curator custody path. |
-| Wait roughly 24 hours for the async FXH flow | Reconcile actual chain state; treat 24 hours as an expectation, not an SLA. |
-| Return EURC and automatically broadcast the stored customer withdrawal | After the human-authorized protocol steps complete, sweep the position, explicitly deallocate FXH-adapter EURC into `VaultV2` when required, re-simulate, and automatically broadcast the unchanged transaction once. |
-| Complete to either wallet or bank account | Resume the exact receiver/off-ramp path encoded by the original customer transaction; the queue must not substitute a destination. |
-| Consider rebalancing after a large withdrawal | Defer rebalancing to a separate decision. |
-| Propose a solution before implementation | Keep this ADR `Proposed` until the controlled integration evidence and operational decisions are approved. |
-| Store the curator key in application environment configuration | Intentionally rejected: use existing human-authorized custody first; constrained automation requires a separate decision; plaintext production keys are prohibited. |
+The customer should see a queued withdrawal instead of a failed transaction. The common liquid-withdrawal path should stay unchanged.
 
 ## Decision
 
-Start with a **bounded backend-first canary**. Do not modify `VaultV2`, `ByzantineEurVaultAdapter`, `EurVaultPosition`, or `ByzantinePrimeEURVault` for v1.
+Start with a bounded backend canary. Do not change `VaultV2`, `ByzantineEurVaultAdapter`, `EurVaultPosition`, or `ByzantinePrimeEURVault` for v1.
 
-The canary will:
+```text
+simulate the customer withdrawal
+├─ success → use the existing immediate path
+└─ approved liquidity-shortfall revert
+   → persist the exact customer-authorized transaction
+   → return a queue ID and notify operations
+   → request a bounded FXH withdrawal
+   → wait for observed FXH settlement
+   → sweep the realized EURC
+   → deallocate it into VaultV2 when required
+   → verify parent-vault idle EURC
+   → re-simulate the unchanged customer transaction
+   → broadcast once or stop in an explicit failure state
+```
 
-1. preserve the existing immediate-withdrawal path unchanged;
-2. enqueue only a positively identified, allowlisted liquidity-shortfall revert from simulation; all gate, authorization, balance, allowance, deadline, and unknown failures remain on the normal failure path;
-3. persist the exact customer-authorized withdrawal transaction and a durable queue record;
-4. return a durable queue identifier and explicit queued status to the caller instead of surfacing the simulated liquidity revert;
-5. notify operators through Telegram when a request queues and on material intervention or terminal transitions;
-6. permit at most one active queued withdrawal per vault and chain;
-7. request a bounded number of bpEUR shares from the FXH adapter through the approved `adapterCurator` custody path;
-8. derive progress from contract state and receipts rather than a fixed delay;
-9. observe or invoke `sweepSettled` after the FXH position settles, using a funded and monitored sender when invocation is required;
-10. unless the FXH adapter is the configured `liquidityAdapter`, have an approved allocator or sentinel call `VaultV2.deallocate` for that adapter to move the realized EURC into parent-vault idle;
-11. verify the actual parent-vault idle EURC produced by that deallocation;
-12. re-simulate the exact customer transaction immediately before broadcast;
-13. broadcast it at most once when simulation succeeds; and
-14. otherwise enter an explicit terminal or operator-review state.
+Only an allowlisted liquidity-shortfall revert may enter the queue. Gate, balance, allowance, deadline, authorization, and unknown failures remain normal failures.
 
-This is **best-effort orchestration**, not an on-chain reservation system. It does not guarantee FIFO fairness, exclusive access to returned liquidity, a fixed settlement time, or successful execution of a transaction whose state has changed while queued.
+The canary supports one active queued withdrawal per vault and chain. A second illiquid request receives a retry-later response.
 
-A contract-enforced share escrow and reservation queue remains the escalation design. It is not approved for implementation until canary evidence or an explicit product/risk requirement demonstrates that the additional guarantees justify the protocol cost.
+This is best-effort orchestration. It does not reserve liquidity on chain or guarantee completion, ordering, payout, or settlement time.
 
-## Performance Principle
+## Why start here
 
-The common liquid-withdrawal path must not pay for the exceptional illiquid path.
+- Immediate withdrawals keep their current gas and latency profile.
+- The implementation is reversible and uses the contracts' existing async withdrawal path.
+- We have no production evidence yet that concurrent fairness or on-chain reservation is required.
 
-For v1:
+A contract escrow and reservation queue remains an escalation option. It is not approved by this ADR.
 
-- no new contract call, token transfer, storage write, or gas cost is added to an immediately executable withdrawal;
-- no new polling or database work occurs for a completed immediate withdrawal beyond existing transaction tracking;
-- all durable queue and reconciliation work is isolated to the insufficient-liquidity branch; and
-- polling must be bounded and back off while FXH settlement is pending.
+## V1 guardrails
 
-## Locked v1 Decisions
+### Customer authorization
 
-### One active request per vault and chain
+The API may store and later broadcast a transaction already authorized by the customer. It must not create or alter the customer's signature, amount, receiver, or destination.
 
-The canary will not solve concurrent fairness or aggregation. If a queued request is active, another illiquid withdrawal is rejected with a clear retry-later status rather than silently joining an unreserved queue.
+Before implementation, a controlled test must prove that the Atlas/Turnkey transaction remains valid for the intended delay. Test at least nonce changes, moved shares or revoked allowance, deadlines or sponsorship expiry, receiver gates, vault configuration, share-price changes, and replay.
 
-This makes ordering deterministic and bounds operational exposure while preserving evidence about attempted overlap.
+If delayed authorization is unsafe, the fallback is simple: prepare liquidity, notify the customer, and ask them to sign again.
 
-### Customer authorization remains customer-owned
+### Protocol authority
 
-The API may retain and later broadcast an exact transaction already authorized by the customer. It must not create or alter the customer signature.
+`requestWithdraw` requires `adapterCurator`. Moving settled EURC from the FXH adapter into `VaultV2` may also require an allocator or sentinel.
 
-Before implementation, a controlled spike must prove that the Atlas/Turnkey transaction remains valid for the maximum intended queue duration. At minimum, the spike must test changes to:
+The first canary uses the currently approved human-authorized custody path for these calls. This ADR does not approve an unattended API-held key. Any later automation needs a separate custody decision and must comply with the API's non-custodial signing rules. Plaintext production keys in application configuration are prohibited.
 
-- nonce;
-- vault-share balance and allowance;
-- transaction deadline or sponsorship validity;
-- receiver eligibility and gates;
-- vault configuration;
-- liquidity and share price; and
-- replay behavior after broadcast.
+### Settlement and accounting
 
-If delayed validity cannot be established safely, v1 falls back to preparing liquidity and asking the customer to re-sign. It does not add contract escrow merely to preserve one-click completion.
+`requestWithdraw` is denominated in bpEUR shares. It cannot request more bpEUR than the adapter holds, and final EURC may be lower after FXH settlement. Record requested shares and reconcile actual EURC.
 
-### Protocol operational authority is separate from customer signing
-
-`ByzantineEurVaultAdapter.requestWithdraw` is restricted to `adapterCurator`. Exercising this protocol role is not authority to sign a customer withdrawal, but its custody still requires explicit security approval.
-
-The initial canary uses the currently approved human-authorized protocol custody path. An unattended API-held or Byzantine-held signing key is not implicitly approved by this ADR. Automating the curator transaction requires a separate signer-custody decision and must reconcile with the API's non-custodial signing guardrail.
-
-If automation is later approved, the signer must be constrained as narrowly as the custody platform permits by chain, contract, function, and operational limits. A plaintext private key in application environment configuration is prohibited.
-
-### FXH unwind and parent-vault deallocation are distinct operations
-
-`requestWithdraw` is denominated in bpEUR shares, not expected EURC. It can request no more than the bpEUR balance already held by `ByzantineEurVaultAdapter`, and the eventual EURC can be lower after FXH settlement. Sizing must therefore record requested bpEUR shares and reconcile the realized EURC rather than treating the initial conversion as guaranteed.
-
-A settled position leaves EURC on `ByzantineEurVaultAdapter`. If another adapter such as Aave is configured as the parent vault's `liquidityAdapter`, the queued customer exit cannot consume that EURC directly. An approved allocator or sentinel must call:
+When Aave is the configured liquidity adapter, settled EURC on the FXH adapter is not yet available to the customer withdrawal. An allocator or sentinel must call:
 
 ```solidity
 VaultV2.deallocate(address(byzantineEurVaultAdapter), "", realizedAssets)
 ```
 
-The call sweeps settled positions inside the adapter and transfers the requested idle EURC into `VaultV2`. The target deployment manifest must establish the actual `liquidityAdapter`, FXH adapter, allocator/sentinel custody, and deallocation path; the backend must not infer them from source defaults.
+The deployment manifest must identify the actual adapters, roles, addresses, token decimals, and deallocation path.
 
-This deallocation authority is a separate protocol role from both customer signing and `adapterCurator`. Human authorization is used in the initial canary unless a later custody decision explicitly approves constrained automation.
+FXH settlement is keeper-driven and may be late, partial, or zero. “Approximately 24 hours” is an expectation, not an SLA.
 
-### No fixed settlement SLA
+### Queue state and retries
 
-FXH settlement is keeper-driven and can be partial, delayed, or zero. “Approximately 24 hours” is an operational expectation, not a contract guarantee. Customer and operator status must reflect observed chain state and pending age without promising a fixed completion time.
-
-### Explicit states and bounded retries
-
-The durable queue must distinguish at least:
+The durable state should be no more detailed than operations need:
 
 ```text
 queued
-→ unwind_authorization_required
-→ unwind_submitted
+→ unwind_required
 → awaiting_fxh_settlement
-→ settlement_swept
-→ vault_deallocation_authorization_required
-→ vault_deallocation_submitted
-→ vault_idle_confirmed
+→ deallocation_required
 → ready_to_broadcast
 → broadcast
 → confirmed
 ```
 
-Terminal or intervention states must include:
+Terminal states: `needs_resign`, `liquidity_conflict`, `cancelled`, `expired`, `operator_review`, and `failed`.
+
+No state retries indefinitely. Record idempotency keys, hashes, nonces, attempt counts, receipts, and the reason work stopped.
+
+### Customer and operator visibility
+
+A queued response includes a stable queue ID and queryable status. The customer-facing response must not expose the internal simulation revert.
+
+The original transaction remains authoritative for wallet or bank/off-ramp destination. For bank withdrawals, the queue hands off to the existing off-ramp lifecycle after the on-chain withdrawal confirms.
+
+Do not describe a queued request as guaranteed or complete before the customer withdrawal confirms. FXH liquidity settlement and downstream bank settlement are separate statuses.
+
+Telegram notifications are required when a request queues, needs human action, exceeds its pending-time threshold, needs re-signing or review, and reaches a terminal state. Notifications are observational; database and chain state remain authoritative.
+
+The canary is automatic from the customer's perspective only when the stored authorization remains valid. Privileged protocol calls remain human-authorized until a separate decision approves automation.
+
+### Rebalancing
+
+Post-withdrawal rebalancing is out of scope. It requires a separate strategy and risk decision.
+
+## Transcript traceability
+
+| July 8 concern | Decision |
+|---|---|
+| Small withdrawals should remain immediate | Keep the current liquid path unchanged. |
+| Large withdrawals should queue instead of reverting | Convert only the approved simulation failure into a queue ID and status. |
+| Store the signed withdrawal | Persist the exact customer-authorized transaction; prove delayed validity first. |
+| Notify the team | Send Telegram notifications for queue, intervention, and terminal events. |
+| Request FXH liquidity and wait roughly 24 hours | Use `adapterCurator`, then follow chain state rather than a fixed timer. |
+| Complete to a wallet or bank account | Preserve the original receiver/off-ramp destination and broadcast once liquidity is available. |
+| Put the curator key in the API environment | Rejected. Start with approved human custody; decide constrained automation separately. |
+| Consider rebalancing later | Deferred. |
+| Propose before implementation | Keep this ADR `Proposed` until the evidence below is reviewed. |
+
+## Evidence required before acceptance
+
+A controlled cross-repository test must prove:
 
 ```text
-needs_resign
-liquidity_conflict
-cancelled
-expired
-operator_review
-failed
+approved simulation failure
+→ persisted customer transaction
+→ bounded requestWithdraw
+→ FXH settlement
+→ sweepSettled
+→ authorized VaultV2.deallocate when required
+→ verified parent-vault idle EURC
+→ successful re-simulation
+→ one broadcast and reconciled receipt
 ```
 
-No state may retry indefinitely. Every transaction submission must have an idempotency key, recorded hash/nonce, bounded attempt count, receipt reconciliation, and an operator-visible reason for stopping.
+It must also cover:
 
-### Customer, destination, and operator visibility
+- stale nonce, moved shares or revoked allowance, expired authorization, and replay;
+- partial or zero settlement;
+- unknown simulation failures, which must never queue;
+- a second illiquid request while one is active;
+- another withdrawal consuming returned EURC;
+- duplicate workers or events and process restart;
+- unavailable protocol authorization or sweep gas; and
+- unsafe sweep/deallocation gas as the position set grows.
 
-A queued API response must contain a stable queue identifier and a queryable status; it must not expose the internal simulation revert as the customer-facing outcome. The status remains pending until the customer withdrawal is confirmed on chain.
+Record the target chain, source revisions, deployed addresses, roles, gates, decimals, finality policy, and signer custody with the test evidence.
 
-The original customer-authorized transaction remains authoritative for amount, receiver, and wallet-versus-off-ramp destination. Queue processing must not replace that destination. For a bank withdrawal, the queue hands control back to the existing off-ramp lifecycle after the on-chain withdrawal transaction is confirmed; bank settlement status remains a downstream concern and must not be conflated with FXH liquidity settlement.
+## Limits and escalation
 
-Telegram notification is required at queue entry, when human authorization is needed, when pending age crosses the approved operational threshold, when re-signing or operator review is required, and on confirmed or failed completion. Notifications are observational only: database and chain state remain authoritative, and duplicate delivery must not change queue state.
+V1 does not guarantee:
 
-The transcript's end-state aspiration is automatic completion without further customer action. The canary provides that only when delayed customer authorization remains valid. It intentionally retains human authorization for privileged curator and parent-vault deallocation calls until a separate custody decision approves automation.
+- on-chain reservation of returned EURC;
+- protection from a competing direct withdrawal;
+- a still-valid customer transaction after the wait;
+- a completion deadline;
+- fairness beyond one active request;
+- a fixed EURC payout; or
+- unattended protocol operations.
 
-### No rebalancing in v1
+Stop the canary and reconsider contract escrow or signer automation if:
 
-Restoring target allocations after an FXH unwind is a separate risk and strategy decision. It is explicitly out of scope for this ADR.
+- returned liquidity is consumed before broadcast;
+- more than one concurrent request is needed;
+- re-signing is too frequent;
+- queued value exceeds the approved risk cap;
+- product requires guaranteed reservation or a composable claim; or
+- manual protocol authorization becomes the bottleneck.
 
-## Required Phase 0 Evidence
+## Alternatives
 
-This ADR remains `Proposed` until a controlled cross-repository integration test proves the following sequence:
+- **Contract escrow now — deferred.** Stronger reservation and fairness, but changes ERC-4626 behavior, adds gas to every withdrawal, and requires migration and audit.
+- **Backend canary — selected.** Preserves the hot path and tests the existing async mechanism with bounded exposure.
+- **Prepare liquidity, then ask the customer to re-sign — fallback.** Use this if delayed transaction validity cannot be proven.
+- **Keep returning the synchronous error — rejected.** It does not solve the customer or operational problem.
 
-```text
-simulate customer withdrawal
-→ positively identify the approved liquidity-shortfall revert
-→ persist the exact authorized transaction
-→ submit a bpEUR-share-bounded adapter requestWithdraw through approved custody
-→ execute/finalize controlled FXH settlement
-→ sweepSettled using a funded sender when needed
-→ observe actual adapter EURC
-→ submit authorized VaultV2.deallocate for the FXH adapter when it is not the configured liquidity adapter
-→ observe actual parent-vault idle EURC
-→ re-simulate the unchanged customer transaction
-→ broadcast once
-→ reconcile the receipt
-```
+## Acceptance
 
-The test must also demonstrate deterministic handling of:
+Change this ADR to `Accepted` only after reviewers approve:
 
-- a changed nonce;
-- moved or insufficient vault shares;
-- invalidated transaction authorization or sponsorship;
-- a partial or zero FXH settlement;
-- a second attempted illiquid request while one is active;
-- another withdrawal consuming returned liquidity before broadcast;
-- duplicate worker execution and duplicate chain events;
-- process restart while each state is active;
-- an FXH batch that remains pending beyond the expected interval;
-- an unknown or non-liquidity simulation revert, which must never enqueue;
-- a requested unwind larger than the adapter's bpEUR balance;
-- a deployment where Aave is the configured liquidity adapter and FXH EURC requires explicit authorized deallocation;
-- failure or delay of the allocator/sentinel deallocation step;
-- a funded sweep sender that is unavailable or underfunded; and
-- a large live-position set that makes sweep/deallocation gas behavior unsafe.
-
-The target chain, deployed addresses, source revisions, roles, gates, token decimals, finality policy, and signer custody must be recorded before the test is treated as production evidence.
-
-## What v1 Guarantees
-
-- The ordinary withdrawal path remains unchanged.
-- A recognized liquidity shortfall becomes an observable durable workflow rather than an opaque revert.
-- The customer-authorized transaction is not modified by the API.
-- FXH unwind and settlement progress are reconciled from chain evidence.
-- Submission is idempotent and bounded.
-- Failure and intervention states are explicit.
-- Canary exposure is bounded by cohort, notional, active-request count, retry count, and pending age.
-- The caller receives a durable queue identifier and queryable status for a recognized liquidity shortfall.
-- Operators receive Telegram notifications for queue entry, intervention thresholds, and terminal outcomes.
-- The original customer-selected wallet or off-ramp destination is preserved.
-
-## What v1 Does Not Guarantee
-
-- Returned EURC is not reserved on chain for the queued transaction.
-- A competing direct withdrawal may consume liquidity first.
-- The customer transaction may become stale while queued.
-- The request has no guaranteed completion time.
-- Queue fairness beyond one active request is not provided.
-- FXH payout or parent-vault asset value is not guaranteed.
-
-These limitations must be present in product and operational language. The system must not describe a queued request as guaranteed or completed before the customer withdrawal is confirmed on chain.
-
-The canary also does not guarantee fully unattended completion: privileged protocol calls remain human-authorized until a separate custody decision approves constrained automation.
-
-## Stop and Escalation Conditions
-
-Stop the canary and review the contract-enforced queue design if any of the following occurs:
-
-1. returned liquidity is consumed by a competing exit before the queued transaction can broadcast;
-2. product demand requires more than one concurrent queued withdrawal per vault;
-3. delayed transactions require re-signing at an unacceptable rate;
-4. queued notional exceeds the approved operational risk cap;
-5. integrators require a composable on-chain claim or transferable withdrawal receipt;
-6. product or risk requires guaranteed FIFO/pro-rata reservation;
-7. manual protocol authorization becomes an operational bottleneck and no acceptable constrained-signer design is approved;
-8. customer or operator evidence shows that queued-response or notification semantics are inadequate; or
-9. end-to-end unattended completion becomes a hard requirement and an acceptable constrained-signer design is approved.
-
-A contract-first follow-up must be a separate ADR. It must define custody, cancellation, partial settlement, allocator interaction, reservation accounting, migration, standard-interface compatibility, and emergency behavior before implementation.
-
-## Options Considered
-
-### Option A: Contract-enforced escrow and reservation immediately
-
-**Deferred.** This provides the strongest customer entitlement and fairness guarantees, but it changes the public protocol before evidence establishes that those guarantees are required. It also makes the normal liquid path more expensive and introduces new accounting and migration risk.
-
-### Option B: Bounded backend-first orchestration
-
-**Selected.** It directly addresses the current UX failure, preserves the existing hot path, uses the asynchronous mechanism already present in the contracts, and produces evidence for or against later protocol changes.
-
-### Option C: Prepare liquidity, then ask the customer to sign again
-
-**Fallback.** This is simpler and avoids retaining a delayed signed transaction, but it requires the customer to return after settlement. It becomes v1 if the Phase 0 delayed-validity test fails.
-
-### Option D: Keep returning the synchronous liquidity error
-
-**Rejected.** This preserves technical simplicity but does not address the product requirement or create an operational path for restoring liquidity.
-
-## Consequences
-
-### Positive
-
-- No contract deployment, migration, or audit is required for the canary.
-- The common withdrawal path keeps its current gas and latency profile.
-- The implementation is reversible and can be disabled without moving customer shares.
-- Real collision, concurrency, signer, settlement-time, and stale-transaction data will inform any later contract design.
-- The contract boundary remains standard for existing integrations.
-
-### Negative
-
-- The canary cannot reserve returned liquidity on chain.
-- Operations participate in adapter-curator and parent-vault deallocation authorization until separate automation decisions are approved.
-- Only one active illiquid request is supported per vault and chain.
-- Some customers may need to re-sign or retry.
-- The backend requires durable queue storage, reconciliation, monitoring, and runbooks.
-- The first canary is not fully unattended because privileged protocol operations remain human-authorized.
-- Telegram notification and a queryable queued response become required operational surfaces.
-
-### Neutral
-
-- FXH keeper and settlement trust assumptions are unchanged.
-- Existing allocator and adapter behavior are unchanged.
-- Rebalancing remains a separate initiative.
-
-## Acceptance and Review
-
-Before changing this ADR to `Accepted`, reviewers must approve:
-
-- the exact allowlisted liquidity-shortfall revert selector and simulation call context;
-- proof that all other simulation failures cannot enqueue;
-- delayed transaction validity or the re-sign fallback;
-- queue and retry limits;
-- customer-facing non-guarantees;
-- the approved adapter-curator custody path;
-- the deployed liquidity adapter and the authorized FXH-adapter-to-parent-vault deallocation path;
-- allocator/sentinel and sweep-sender custody, funding, and monitoring;
-- bpEUR unwind-sizing bounds and realized-EURC reconciliation;
-- deployment metadata and finality policy;
-- controlled integration-test evidence;
-- operational ownership and stop authority for the canary;
-- the queued API response contract and status-query surface;
-- Telegram notification recipients, deduplication, and escalation thresholds;
-- preservation of wallet/off-ramp destination and handoff to existing downstream tracking; and
-- whether human-authorized privileged calls satisfy the canary or automation is a release requirement.
+- the exact liquidity-shortfall revert classification;
+- delayed authorization or the re-sign fallback;
+- queue, retry, pending-time, and value limits;
+- curator, allocator/sentinel, and sweep custody;
+- deployment metadata and bpEUR-to-realized-EURC accounting;
+- customer status, destination handoff, Telegram escalation, and stated non-guarantees; and
+- the controlled integration-test evidence and operational owner.
 
 ## References
 
@@ -333,5 +208,5 @@ Before changing this ADR to `Accepted`, reviewers must approve:
 - [`src/adapters/EurVaultPosition.sol`](../../src/adapters/EurVaultPosition.sol)
 - [`Byzantine-Finance/fx-hedge-contract`](https://github.com/Byzantine-Finance/fx-hedge-contract)
 - [`Byzantine-Finance/byzantine-api`](https://github.com/Byzantine-Finance/byzantine-api)
-- [`byzantine-api/docs/adr/0002-standing-integrator-delegated-authority.md`](https://github.com/Byzantine-Finance/byzantine-api/blob/dev/docs/adr/0002-standing-integrator-delegated-authority.md)
+- [`byzantine-api ADR 0002`](https://github.com/Byzantine-Finance/byzantine-api/blob/dev/docs/adr/0002-standing-integrator-delegated-authority.md)
 - Internal product discussion, 2026-07-08

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -41,7 +41,7 @@ simulate the customer withdrawal
    → broadcast once or stop in an explicit failure state
 ```
 
-Only an allowlisted liquidity-shortfall revert may enter the queue. Gate, balance, allowance, deadline, authorization, and unknown failures remain normal failures.
+Only an allowlisted liquidity-shortfall revert may enter the queue. Gate, balance, allowance, Atlas nonce, authorization, and unknown failures remain normal failures.
 
 The canary supports one active queued withdrawal per vault and chain. A second illiquid request receives a retry-later response.
 
@@ -61,20 +61,20 @@ A contract escrow and reservation queue remains an escalation option. It is not 
 
 Queue admission has two distinct checks:
 
-- **Authoritative:** simulate the Atlas inner withdrawal call from the wallet address and enqueue only a positively identified liquidity-shortfall selector from the expected vault call. Validate the Atlas authorization, deadline, and unused nonce separately because the current simulation executes inner calls directly rather than the Atlas envelope.
+- **Authoritative:** simulate the Atlas inner withdrawal call from the wallet address and enqueue only a positively identified liquidity-shortfall selector from the expected vault call. Validate the exact persisted Atlas authorization and unused nonce separately because the current simulation executes inner calls directly rather than the Atlas envelope.
 - **Advisory:** RPC liquidity reads may improve the response shown before signing, but must not decide queue admission until their equation is defined and tested. `AaveStrategy.realAssets()` is the strategy's aToken claim plus idle assets; it is not guaranteed immediately withdrawable Aave liquidity.
 
 The evidence fixture captures a controlled source-only FXH `InsufficientIdle()` path and, separately, the deployed Aave/MYT path at pinned block `25,576,274`. The canary classifier for this vault/chain must match the deployed raw selector `0x47bc4b2c`, expected call target, and exact call context. Matching an error message string is forbidden.
 
 ### Customer authorization
 
-All Byzantine wallets use the EIP-7702 Atlas delegation. Atlas supports sponsored execution, a deadline, and replay protection after a successful call; it does not force withdrawals through the Byzantine API.
+All Byzantine wallets use the EIP-7702 Atlas delegation. Atlas supports sponsored execution and replay protection after a successful call; it does not force withdrawals through the Byzantine API.
 
-The API may store and later broadcast an exact transaction already authorized by the customer. It must not create or alter the customer's signature, amount, receiver, or destination. A failed Atlas execution rolls back Atlas nonce consumption, so the authorization may remain usable. The current API uses an effectively unbounded deadline; the canary must use a bounded withdrawal deadline or an explicit revocation mechanism before delayed automatic broadcast is approved.
+The customer authorizes one exact withdrawal call once. V1 persists its exact call bytes, signature components, nonce, and `u64::MAX` Atlas deadline, then later broadcasts that unchanged authorization after final re-simulation. The backend cannot alter the signature, amount, receiver, destination, target, value, or calldata.
 
-A controlled test must cover moved shares or revoked allowance, nonce reuse, deadline and sponsorship expiry, receiver gates, vault configuration, share-price changes, failed execution, and replay.
+This is an intentional final, single-use bearer authorization: any holder of the exact signature/call tuple may relay it until the first successful Atlas execution consumes the nonce. Atlas provides no nonce invalidation or cancellation primitive. API deletion or a customer-facing cancellation flag is operational only and must never be described as revocation. A failed Atlas execution rolls back nonce consumption, so the authorization remains usable.
 
-If delayed authorization is unsafe, the fallback is simple: prepare liquidity, notify the customer, and ask them to sign again.
+Controlled tests must cover moved shares or revoked allowance, Atlas nonce reuse, receiver gates, vault configuration, share-price changes, failed execution, replay, and the exact persisted call/signature release path. Customer copy must state that authorization is final until execution; no re-sign fallback exists in v1.
 
 ### Protocol authority
 
@@ -112,7 +112,7 @@ queued
 → confirmed
 ```
 
-Terminal states: `needs_resign`, `liquidity_conflict`, `cancelled`, `expired`, `operator_review`, and `failed`.
+Terminal states: `liquidity_conflict`, `operator_review`, `failed`, and any explicit final reconciliation failure. There is no v1 `needs_resign`, `cancelled`, or `expired` authorization state.
 
 No state retries indefinitely. Record idempotency keys, hashes, nonces, attempt counts, receipts, and the reason work stopped.
 
@@ -136,9 +136,9 @@ The original transaction remains authoritative for wallet or bank/off-ramp desti
 
 Do not describe a queued request as guaranteed or complete before the customer withdrawal confirms. FXH liquidity settlement and downstream bank settlement are separate statuses.
 
-Telegram notifications are required when a request queues, needs human action, exceeds its pending-time threshold, needs re-signing or review, and reaches a terminal state. Notifications are observational; database and chain state remain authoritative.
+Telegram notifications are required when a request queues, needs human action, exceeds its pending-time threshold, reaches operator review, and reaches a terminal state. Notifications are observational; database and chain state remain authoritative.
 
-The canary is automatic from the customer's perspective only when the stored authorization remains valid. Privileged protocol calls remain human-authorized until a separate decision approves automation.
+The canary is automatic from the customer's perspective because it retains the final exact authorization. Privileged protocol calls remain human-authorized until a separate decision approves automation.
 
 ### Rebalancing
 
@@ -184,7 +184,7 @@ approved simulation failure
 
 It must also cover:
 
-- stale nonce, moved shares or revoked allowance, expired authorization, and replay;
+- stale Atlas nonce, moved shares or revoked allowance, exact-call/signature persistence, failed execution, and replay;
 - partial or zero settlement;
 - unknown simulation failures, which must never queue;
 - a second illiquid request while one is active;
@@ -194,7 +194,7 @@ It must also cover:
 - unsafe sweep/deallocation gas as the position set grows;
 - the same liquidity classification against fake vaults and a pinned production fork;
 - a whitelisted fork wallet and receiver, plus negative gate tests;
-- Atlas authorization with a bounded deadline or a tested revocation path;
+- the final exact Atlas authorization commitment, no-cancellation disclosure, and release path;
 - separate wallet-entitlement, per-wallet queued-commitment, and global queue-capacity calculations; and
 - a direct-wallet attempt that bypasses the API, with the documented v1 response.
 
@@ -206,8 +206,8 @@ V1 does not guarantee:
 
 - on-chain reservation of returned EURC;
 - protection from a competing direct withdrawal;
-- a still-valid customer transaction after the wait;
-- a completion deadline;
+- protection from a competing direct withdrawal;
+- a successful customer withdrawal after the wait if final re-simulation fails;
 - fairness beyond one active request;
 - a fixed EURC payout;
 - unattended protocol operations; or
@@ -217,7 +217,7 @@ Stop the canary and reconsider contract escrow or signer automation if:
 
 - returned liquidity is consumed before broadcast;
 - more than one concurrent request is needed;
-- re-signing is too frequent;
+- exact authorization persistence or release cannot be proven safe;
 - queued value exceeds the approved risk cap;
 - product requires guaranteed reservation or a composable claim;
 - manual protocol authorization becomes the bottleneck;
@@ -227,8 +227,8 @@ Stop the canary and reconsider contract escrow or signer automation if:
 ## Alternatives
 
 - **Contract escrow now — deferred.** Stronger reservation and fairness, but changes ERC-4626 behavior, adds gas to every withdrawal, and requires migration and audit.
-- **Backend canary — selected.** Preserves the hot path and tests the existing async mechanism with bounded exposure.
-- **Prepare liquidity, then ask the customer to re-sign — fallback.** Use this if delayed transaction validity cannot be proven.
+- **Backend canary — selected.** Preserves the hot path, uses a final exact Atlas authorization for no-resign UX, and tests the existing async mechanism with bounded exposure.
+- **Prepare liquidity, then ask the customer to re-sign — rejected.** It violates the required withdrawal UX.
 - **Keep returning the synchronous error — rejected.** It does not solve the customer or operational problem.
 
 ## Canary rollout gates
@@ -236,15 +236,14 @@ Stop the canary and reconsider contract escrow or signer automation if:
 Do not enable the canary until reviewers approve:
 
 - the exact liquidity-shortfall revert classification;
-- delayed authorization or the re-sign fallback;
+- final exact Atlas authorization semantics and no-cancellation disclosure;
 - queue, retry, pending-time, and value limits;
 - curator, allocator/sentinel, and sweep custody;
 - deployment metadata and bpEUR-to-realized-EURC accounting;
 - customer status, destination handoff, Telegram escalation, and stated non-guarantees;
 - the controlled integration-test evidence and operational owner;
 - the separation between wallet entitlement, per-wallet queued commitment, and global queue capacity;
-- the fake-vault and whitelisted-fork revert-classification evidence;
-- a bounded Atlas deadline or revocation mechanism; and
+- the fake-vault and whitelisted-fork revert-classification evidence; and
 - the explicit API-only coverage decision or an approved Hypernative design.
 
 ## References

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -10,7 +10,7 @@
 
 `VaultV2` serves withdrawals synchronously. It uses idle EURC first, then asks its configured liquidity adapter for the shortfall. If the adapter cannot provide enough EURC, the transaction reverts.
 
-The July 8 discussion described Aave as the liquid adapter holding roughly 10% of vault assets and the FXH adapter holding roughly 85%. These are deployment observations, not source defaults. We must verify the live configuration before implementation.
+At mainnet block `25,576,274`, the official vault's configured liquidity adapter is `0x4167785e9f3Ecd173Aa4c21Ab6fb1aBB4D5Be050`, an Aave/MYT strategy identified by its `MYT`, `mytAsset`, and `aToken` ABI. The July 8 allocation percentages were not the current withdrawal routing configuration. The pinned-fork evidence fixture captures the deployed shortfall through this adapter as raw revert `0x47bc4b2c` (`NotEnoughAvailableUserBalance()`).
 
 Liquidity can return from FXH through the existing contracts:
 
@@ -64,7 +64,7 @@ Queue admission has two distinct checks:
 - **Authoritative:** simulate the Atlas inner withdrawal call from the wallet address and enqueue only a positively identified liquidity-shortfall selector from the expected vault call. Validate the Atlas authorization, deadline, and unused nonce separately because the current simulation executes inner calls directly rather than the Atlas envelope.
 - **Advisory:** RPC liquidity reads may improve the response shown before signing, but must not decide queue admission until their equation is defined and tested. `AaveStrategy.realAssets()` is the strategy's aToken claim plus idle assets; it is not guaranteed immediately withdrawable Aave liquidity.
 
-Benoit's fake-vault tests must establish stable liquidity and non-liquidity selectors. A production fork must then prove the classification through the deployed VaultV2, Aave strategy, and gates. Matching an error message string alone is not sufficient.
+The evidence fixture captures a controlled source-only FXH `InsufficientIdle()` path and, separately, the deployed Aave/MYT path at pinned block `25,576,274`. The canary classifier for this vault/chain must match the deployed raw selector `0x47bc4b2c`, expected call target, and exact call context. Matching an error message string is forbidden.
 
 ### Customer authorization
 
@@ -88,7 +88,7 @@ Alex will assess whether Hypernative can cover withdrawals submitted outside the
 
 `requestWithdraw` is denominated in bpEUR shares. It cannot request more bpEUR than the adapter holds, and final EURC may be lower after FXH settlement. Record requested shares and reconcile actual EURC.
 
-When Aave is the configured liquidity adapter, settled EURC on the FXH adapter is not yet available to the customer withdrawal. An allocator or sentinel must call:
+The verified deployment currently uses Aave/MYT as `liquidityAdapter`. Settled EURC on the FXH adapter is therefore not yet available to a customer withdrawal. An allocator or sentinel must call:
 
 ```solidity
 VaultV2.deallocate(address(byzantineEurVaultAdapter), "", realizedAssets)
@@ -160,11 +160,11 @@ Post-withdrawal rebalancing is out of scope. It requires a separate strategy and
 
 ## Open research and owners
 
-- **Benoit — revert classification:** deploy controlled fake vaults to exercise known failures, then repeat the full path on a pinned fork using official deployment addresses. Whitelist the test wallet and receiver before classifying any revert; a gate failure is not a liquidity failure.
+- **Complete — deployed liquidity classification:** `test/integration/FxhWithdrawalQueueEvidenceTest.sol` captures the official vault's pinned Aave/MYT shortfall selector and a distinct gate-negative control. The evidence is limited to the listed vault, chain, block, call shape, and selector.
 - **Alex — Hypernative/API split:** determine whether Hypernative can observe API-bypassing attempts and safely trigger a bounded unwind. Document custody, deduplication, griefing controls, and which system owns each state transition.
 - **Vault/API — Aave estimate:** define and test an advisory available-liquidity equation. It must account for vault idle, strategy idle, the adapter's aToken claim, actual Aave reserve liquidity, and conditions that can still make `pool.withdraw` revert.
 
-Until these are resolved, simulation remains the only queue-admission authority and the canary covers API-observed requests only.
+Simulation remains the only queue-admission authority. The verified selector applies only to the pinned vault/chain/call context; canary coverage remains API-observed.
 
 ## Evidence required before canary rollout
 

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -1,7 +1,8 @@
 # ADR 0001: Backend-First FXH Withdrawal Orchestration
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-14
+- **Accepted:** 2026-07-20
 - **Owners:** Vault, FXH, API, Product, Security, and Operations maintainers
 - **Scope:** EUR vault withdrawals that exceed immediately available liquidity
 
@@ -155,7 +156,7 @@ Post-withdrawal rebalancing is out of scope. It requires a separate strategy and
 | Complete to a wallet or bank account | Preserve the original receiver/off-ramp destination and broadcast once liquidity is available. |
 | Put the curator key in the API environment | Rejected. Start with approved human custody; decide constrained automation separately. |
 | Consider rebalancing later | Deferred. |
-| Propose before implementation | Keep this ADR `Proposed` until the evidence below is reviewed. |
+| Propose before implementation | Decision accepted; canary rollout remains gated by the evidence below. |
 
 ## Open research and owners
 
@@ -165,7 +166,7 @@ Post-withdrawal rebalancing is out of scope. It requires a separate strategy and
 
 Until these are resolved, simulation remains the only queue-admission authority and the canary covers API-observed requests only.
 
-## Evidence required before acceptance
+## Evidence required before canary rollout
 
 A controlled cross-repository test must prove:
 
@@ -230,9 +231,9 @@ Stop the canary and reconsider contract escrow or signer automation if:
 - **Prepare liquidity, then ask the customer to re-sign — fallback.** Use this if delayed transaction validity cannot be proven.
 - **Keep returning the synchronous error — rejected.** It does not solve the customer or operational problem.
 
-## Acceptance
+## Canary rollout gates
 
-Change this ADR to `Accepted` only after reviewers approve:
+Do not enable the canary until reviewers approve:
 
 - the exact liquidity-shortfall revert classification;
 - delayed authorization or the re-sign fallback;

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -1,0 +1,294 @@
+# ADR 0001: Backend-First FXH Withdrawal Orchestration
+
+- **Status:** Proposed
+- **Date:** 2026-07-14
+- **Decision owners:** Vault, FXH, API, Product, Security, and Operations maintainers
+- **Scope:** EUR vault withdrawals that cannot be satisfied immediately by the configured liquidity adapter
+
+## Context
+
+`VaultV2` serves ordinary ERC-4626 withdrawals synchronously. Its exit path uses idle EURC first and then asks the configured liquidity adapter to deallocate the shortfall. If the adapter cannot provide enough idle EURC, the transaction reverts.
+
+`ByzantineEurVaultAdapter` already provides the asynchronous path needed to recover liquidity from the FX hedge vault:
+
+1. its `adapterCurator` calls `requestWithdraw`;
+2. the adapter creates or reuses an `EurVaultPosition` for the active FXH batch;
+3. the position requests withdrawal from `ByzantinePrimeEURVault`;
+4. FXH settlement completes through its keeper-driven daily net transfer process;
+5. `sweepSettled` returns realized EURC to the FXH adapter;
+6. unless the FXH adapter is itself the configured `liquidityAdapter`, an authorized `VaultV2` allocator or sentinel must call `VaultV2.deallocate` for the FXH adapter to pull that EURC into parent-vault idle; and
+7. only then can a later standard `VaultV2` exit consume the returned EURC.
+
+The current customer experience exposes the synchronous failure. The desired experience is to preserve the normal fast withdrawal path and coordinate the asynchronous path when liquidity is unavailable.
+
+The first proposed architecture replaced all exits with a new on-chain share escrow, reservation queue, and exclusive withdrawal gateway. That architecture would provide stronger fairness and reservation guarantees, but it would also:
+
+- change standard ERC-4626 withdrawal behavior and integrations;
+- add calls, transfers, storage writes, and gas to every withdrawal;
+- couple queue accounting to `VaultV2`, adapter positions, FXH batch settlement, allocator actions, and haircut behavior;
+- require a protocol migration, role changes, and a dedicated audit; and
+- solve concurrency and fairness requirements that have not yet been demonstrated by production evidence.
+
+The July 8 product discussion described a backend queue rather than a replacement withdrawal protocol. We therefore need the smallest reversible implementation that tests the actual operational assumptions without imposing a hot-path regression.
+
+## Decision
+
+Start with a **bounded backend-first canary**. Do not modify `VaultV2`, `ByzantineEurVaultAdapter`, `EurVaultPosition`, or `ByzantinePrimeEURVault` for v1.
+
+The canary will:
+
+1. preserve the existing immediate-withdrawal path unchanged;
+2. enqueue only a positively identified, allowlisted liquidity-shortfall revert from simulation; all gate, authorization, balance, allowance, deadline, and unknown failures remain on the normal failure path;
+3. persist the exact customer-authorized withdrawal transaction and a durable queue record;
+4. permit at most one active queued withdrawal per vault and chain;
+5. request a bounded number of bpEUR shares from the FXH adapter through the approved `adapterCurator` custody path;
+6. derive progress from contract state and receipts rather than a fixed delay;
+7. observe or invoke `sweepSettled` after the FXH position settles, using a funded and monitored sender when invocation is required;
+8. unless the FXH adapter is the configured `liquidityAdapter`, have an approved allocator or sentinel call `VaultV2.deallocate` for that adapter to move the realized EURC into parent-vault idle;
+9. verify the actual parent-vault idle EURC produced by that deallocation;
+10. re-simulate the exact customer transaction immediately before broadcast;
+11. broadcast it at most once when simulation succeeds; and
+12. otherwise enter an explicit terminal or operator-review state.
+
+This is **best-effort orchestration**, not an on-chain reservation system. It does not guarantee FIFO fairness, exclusive access to returned liquidity, a fixed settlement time, or successful execution of a transaction whose state has changed while queued.
+
+A contract-enforced share escrow and reservation queue remains the escalation design. It is not approved for implementation until canary evidence or an explicit product/risk requirement demonstrates that the additional guarantees justify the protocol cost.
+
+## Performance Principle
+
+The common liquid-withdrawal path must not pay for the exceptional illiquid path.
+
+For v1:
+
+- no new contract call, token transfer, storage write, or gas cost is added to an immediately executable withdrawal;
+- no new polling or database work occurs for a completed immediate withdrawal beyond existing transaction tracking;
+- all durable queue and reconciliation work is isolated to the insufficient-liquidity branch; and
+- polling must be bounded and back off while FXH settlement is pending.
+
+## Locked v1 Decisions
+
+### One active request per vault and chain
+
+The canary will not solve concurrent fairness or aggregation. If a queued request is active, another illiquid withdrawal is rejected with a clear retry-later status rather than silently joining an unreserved queue.
+
+This makes ordering deterministic and bounds operational exposure while preserving evidence about attempted overlap.
+
+### Customer authorization remains customer-owned
+
+The API may retain and later broadcast an exact transaction already authorized by the customer. It must not create or alter the customer signature.
+
+Before implementation, a controlled spike must prove that the Atlas/Turnkey transaction remains valid for the maximum intended queue duration. At minimum, the spike must test changes to:
+
+- nonce;
+- vault-share balance and allowance;
+- transaction deadline or sponsorship validity;
+- receiver eligibility and gates;
+- vault configuration;
+- liquidity and share price; and
+- replay behavior after broadcast.
+
+If delayed validity cannot be established safely, v1 falls back to preparing liquidity and asking the customer to re-sign. It does not add contract escrow merely to preserve one-click completion.
+
+### Protocol operational authority is separate from customer signing
+
+`ByzantineEurVaultAdapter.requestWithdraw` is restricted to `adapterCurator`. Exercising this protocol role is not authority to sign a customer withdrawal, but its custody still requires explicit security approval.
+
+The initial canary uses the currently approved human-authorized protocol custody path. An unattended API-held or Byzantine-held signing key is not implicitly approved by this ADR. Automating the curator transaction requires a separate signer-custody decision and must reconcile with the API's non-custodial signing guardrail.
+
+If automation is later approved, the signer must be constrained as narrowly as the custody platform permits by chain, contract, function, and operational limits. A plaintext private key in application environment configuration is prohibited.
+
+### FXH unwind and parent-vault deallocation are distinct operations
+
+`requestWithdraw` is denominated in bpEUR shares, not expected EURC. It can request no more than the bpEUR balance already held by `ByzantineEurVaultAdapter`, and the eventual EURC can be lower after FXH settlement. Sizing must therefore record requested bpEUR shares and reconcile the realized EURC rather than treating the initial conversion as guaranteed.
+
+A settled position leaves EURC on `ByzantineEurVaultAdapter`. If another adapter such as Aave is configured as the parent vault's `liquidityAdapter`, the queued customer exit cannot consume that EURC directly. An approved allocator or sentinel must call:
+
+```solidity
+VaultV2.deallocate(address(byzantineEurVaultAdapter), "", realizedAssets)
+```
+
+The call sweeps settled positions inside the adapter and transfers the requested idle EURC into `VaultV2`. The target deployment manifest must establish the actual `liquidityAdapter`, FXH adapter, allocator/sentinel custody, and deallocation path; the backend must not infer them from source defaults.
+
+This deallocation authority is a separate protocol role from both customer signing and `adapterCurator`. Human authorization is used in the initial canary unless a later custody decision explicitly approves constrained automation.
+
+### No fixed settlement SLA
+
+FXH settlement is keeper-driven and can be partial, delayed, or zero. “Approximately 24 hours” is an operational expectation, not a contract guarantee. Customer and operator status must reflect observed chain state and pending age without promising a fixed completion time.
+
+### Explicit states and bounded retries
+
+The durable queue must distinguish at least:
+
+```text
+queued
+→ unwind_authorization_required
+→ unwind_submitted
+→ awaiting_fxh_settlement
+→ settlement_swept
+→ vault_deallocation_authorization_required
+→ vault_deallocation_submitted
+→ vault_idle_confirmed
+→ ready_to_broadcast
+→ broadcast
+→ confirmed
+```
+
+Terminal or intervention states must include:
+
+```text
+needs_resign
+liquidity_conflict
+cancelled
+expired
+operator_review
+failed
+```
+
+No state may retry indefinitely. Every transaction submission must have an idempotency key, recorded hash/nonce, bounded attempt count, receipt reconciliation, and an operator-visible reason for stopping.
+
+### No rebalancing in v1
+
+Restoring target allocations after an FXH unwind is a separate risk and strategy decision. It is explicitly out of scope for this ADR.
+
+## Required Phase 0 Evidence
+
+This ADR remains `Proposed` until a controlled cross-repository integration test proves the following sequence:
+
+```text
+simulate customer withdrawal
+→ positively identify the approved liquidity-shortfall revert
+→ persist the exact authorized transaction
+→ submit a bpEUR-share-bounded adapter requestWithdraw through approved custody
+→ execute/finalize controlled FXH settlement
+→ sweepSettled using a funded sender when needed
+→ observe actual adapter EURC
+→ submit authorized VaultV2.deallocate for the FXH adapter when it is not the configured liquidity adapter
+→ observe actual parent-vault idle EURC
+→ re-simulate the unchanged customer transaction
+→ broadcast once
+→ reconcile the receipt
+```
+
+The test must also demonstrate deterministic handling of:
+
+- a changed nonce;
+- moved or insufficient vault shares;
+- invalidated transaction authorization or sponsorship;
+- a partial or zero FXH settlement;
+- a second attempted illiquid request while one is active;
+- another withdrawal consuming returned liquidity before broadcast;
+- duplicate worker execution and duplicate chain events;
+- process restart while each state is active;
+- an FXH batch that remains pending beyond the expected interval;
+- an unknown or non-liquidity simulation revert, which must never enqueue;
+- a requested unwind larger than the adapter's bpEUR balance;
+- a deployment where Aave is the configured liquidity adapter and FXH EURC requires explicit authorized deallocation;
+- failure or delay of the allocator/sentinel deallocation step;
+- a funded sweep sender that is unavailable or underfunded; and
+- a large live-position set that makes sweep/deallocation gas behavior unsafe.
+
+The target chain, deployed addresses, source revisions, roles, gates, token decimals, finality policy, and signer custody must be recorded before the test is treated as production evidence.
+
+## What v1 Guarantees
+
+- The ordinary withdrawal path remains unchanged.
+- A recognized liquidity shortfall becomes an observable durable workflow rather than an opaque revert.
+- The customer-authorized transaction is not modified by the API.
+- FXH unwind and settlement progress are reconciled from chain evidence.
+- Submission is idempotent and bounded.
+- Failure and intervention states are explicit.
+- Canary exposure is bounded by cohort, notional, active-request count, retry count, and pending age.
+
+## What v1 Does Not Guarantee
+
+- Returned EURC is not reserved on chain for the queued transaction.
+- A competing direct withdrawal may consume liquidity first.
+- The customer transaction may become stale while queued.
+- The request has no guaranteed completion time.
+- Queue fairness beyond one active request is not provided.
+- FXH payout or parent-vault asset value is not guaranteed.
+
+These limitations must be present in product and operational language. The system must not describe a queued request as guaranteed or completed before the customer withdrawal is confirmed on chain.
+
+## Stop and Escalation Conditions
+
+Stop the canary and review the contract-enforced queue design if any of the following occurs:
+
+1. returned liquidity is consumed by a competing exit before the queued transaction can broadcast;
+2. product demand requires more than one concurrent queued withdrawal per vault;
+3. delayed transactions require re-signing at an unacceptable rate;
+4. queued notional exceeds the approved operational risk cap;
+5. integrators require a composable on-chain claim or transferable withdrawal receipt;
+6. product or risk requires guaranteed FIFO/pro-rata reservation; or
+7. manual protocol authorization becomes an operational bottleneck and no acceptable constrained-signer design is approved.
+
+A contract-first follow-up must be a separate ADR. It must define custody, cancellation, partial settlement, allocator interaction, reservation accounting, migration, standard-interface compatibility, and emergency behavior before implementation.
+
+## Options Considered
+
+### Option A: Contract-enforced escrow and reservation immediately
+
+**Deferred.** This provides the strongest customer entitlement and fairness guarantees, but it changes the public protocol before evidence establishes that those guarantees are required. It also makes the normal liquid path more expensive and introduces new accounting and migration risk.
+
+### Option B: Bounded backend-first orchestration
+
+**Selected.** It directly addresses the current UX failure, preserves the existing hot path, uses the asynchronous mechanism already present in the contracts, and produces evidence for or against later protocol changes.
+
+### Option C: Prepare liquidity, then ask the customer to sign again
+
+**Fallback.** This is simpler and avoids retaining a delayed signed transaction, but it requires the customer to return after settlement. It becomes v1 if the Phase 0 delayed-validity test fails.
+
+### Option D: Keep returning the synchronous liquidity error
+
+**Rejected.** This preserves technical simplicity but does not address the product requirement or create an operational path for restoring liquidity.
+
+## Consequences
+
+### Positive
+
+- No contract deployment, migration, or audit is required for the canary.
+- The common withdrawal path keeps its current gas and latency profile.
+- The implementation is reversible and can be disabled without moving customer shares.
+- Real collision, concurrency, signer, settlement-time, and stale-transaction data will inform any later contract design.
+- The contract boundary remains standard for existing integrations.
+
+### Negative
+
+- The canary cannot reserve returned liquidity on chain.
+- Operations participate in adapter-curator and parent-vault deallocation authorization until separate automation decisions are approved.
+- Only one active illiquid request is supported per vault and chain.
+- Some customers may need to re-sign or retry.
+- The backend requires durable queue storage, reconciliation, monitoring, and runbooks.
+
+### Neutral
+
+- FXH keeper and settlement trust assumptions are unchanged.
+- Existing allocator and adapter behavior are unchanged.
+- Rebalancing remains a separate initiative.
+
+## Acceptance and Review
+
+Before changing this ADR to `Accepted`, reviewers must approve:
+
+- the exact allowlisted liquidity-shortfall revert selector and simulation call context;
+- proof that all other simulation failures cannot enqueue;
+- delayed transaction validity or the re-sign fallback;
+- queue and retry limits;
+- customer-facing non-guarantees;
+- the approved adapter-curator custody path;
+- the deployed liquidity adapter and the authorized FXH-adapter-to-parent-vault deallocation path;
+- allocator/sentinel and sweep-sender custody, funding, and monitoring;
+- bpEUR unwind-sizing bounds and realized-EURC reconciliation;
+- deployment metadata and finality policy;
+- controlled integration-test evidence; and
+- operational ownership and stop authority for the canary.
+
+## References
+
+- [`src/VaultV2.sol`](../../src/VaultV2.sol)
+- [`src/adapters/ByzantineEurVaultAdapter.sol`](../../src/adapters/ByzantineEurVaultAdapter.sol)
+- [`src/adapters/EurVaultPosition.sol`](../../src/adapters/EurVaultPosition.sol)
+- [`Byzantine-Finance/fx-hedge-contract`](https://github.com/Byzantine-Finance/fx-hedge-contract)
+- [`Byzantine-Finance/byzantine-api`](https://github.com/Byzantine-Finance/byzantine-api)
+- [`byzantine-api/docs/adr/0002-standing-integrator-delegated-authority.md`](https://github.com/Byzantine-Finance/byzantine-api/blob/dev/docs/adr/0002-standing-integrator-delegated-authority.md)
+- Internal product discussion, 2026-07-08

--- a/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
+++ b/docs/adr/0001-backend-first-fxh-withdrawal-orchestration.md
@@ -56,11 +56,22 @@ A contract escrow and reservation queue remains an escalation option. It is not 
 
 ## V1 guardrails
 
+### Liquidity admission
+
+Queue admission has two distinct checks:
+
+- **Authoritative:** simulate the Atlas inner withdrawal call from the wallet address and enqueue only a positively identified liquidity-shortfall selector from the expected vault call. Validate the Atlas authorization, deadline, and unused nonce separately because the current simulation executes inner calls directly rather than the Atlas envelope.
+- **Advisory:** RPC liquidity reads may improve the response shown before signing, but must not decide queue admission until their equation is defined and tested. `AaveStrategy.realAssets()` is the strategy's aToken claim plus idle assets; it is not guaranteed immediately withdrawable Aave liquidity.
+
+Benoit's fake-vault tests must establish stable liquidity and non-liquidity selectors. A production fork must then prove the classification through the deployed VaultV2, Aave strategy, and gates. Matching an error message string alone is not sufficient.
+
 ### Customer authorization
 
-The API may store and later broadcast a transaction already authorized by the customer. It must not create or alter the customer's signature, amount, receiver, or destination.
+All Byzantine wallets use the EIP-7702 Atlas delegation. Atlas supports sponsored execution, a deadline, and replay protection after a successful call; it does not force withdrawals through the Byzantine API.
 
-Before implementation, a controlled test must prove that the Atlas/Turnkey transaction remains valid for the intended delay. Test at least nonce changes, moved shares or revoked allowance, deadlines or sponsorship expiry, receiver gates, vault configuration, share-price changes, and replay.
+The API may store and later broadcast an exact transaction already authorized by the customer. It must not create or alter the customer's signature, amount, receiver, or destination. A failed Atlas execution rolls back Atlas nonce consumption, so the authorization may remain usable. The current API uses an effectively unbounded deadline; the canary must use a bounded withdrawal deadline or an explicit revocation mechanism before delayed automatic broadcast is approved.
+
+A controlled test must cover moved shares or revoked allowance, nonce reuse, deadline and sponsorship expiry, receiver gates, vault configuration, share-price changes, failed execution, and replay.
 
 If delayed authorization is unsafe, the fallback is simple: prepare liquidity, notify the customer, and ask them to sign again.
 
@@ -69,6 +80,8 @@ If delayed authorization is unsafe, the fallback is simple: prepare liquidity, n
 `requestWithdraw` requires `adapterCurator`. Moving settled EURC from the FXH adapter into `VaultV2` may also require an allocator or sentinel.
 
 The first canary uses the currently approved human-authorized custody path for these calls. This ADR does not approve an unattended API-held key. Any later automation needs a separate custody decision and must comply with the API's non-custodial signing rules. Plaintext production keys in application configuration are prohibited.
+
+Alex will assess whether Hypernative can cover withdrawals submitted outside the Byzantine API. Hypernative is not selected by this ADR. Before it can trigger `requestWithdraw`, the design must define observation coverage, curator custody, sizing, idempotency, caps, duplicate suppression, and resistance to deliberately failing withdrawals. A failed direct-wallet transaction is not by itself a durable API queue record or proof that the customer still wants an unwind. Without reusable customer authorization, Hypernative could only replenish liquidity; the customer would still have to retry the withdrawal.
 
 ### Settlement and accounting
 
@@ -102,6 +115,18 @@ Terminal states: `needs_resign`, `liquidity_conflict`, `cancelled`, `expired`, `
 
 No state retries indefinitely. Record idempotency keys, hashes, nonces, attempt counts, receipts, and the reason work stopped.
 
+### Withdrawal limits and queued amounts
+
+`get_vault_v2_max_withdrawal` currently calculates a wallet's asset entitlement from its vault shares. Subtracting the global queued total from that value would mix user ownership with system liquidity and understate unrelated users' entitlement.
+
+Keep these concepts separate:
+
+- **wallet entitlement:** the existing maximum based on the wallet's shares;
+- **API-requestable amount:** wallet entitlement less that wallet's active queued commitment; and
+- **remaining queue capacity:** the canary risk cap less all active queued commitments.
+
+The durable one-active-request rule is the admission lock. These API values are advisory and cannot prevent a direct wallet transaction from moving shares or consuming liquidity; final simulation and chain reconciliation remain required.
+
 ### Customer and operator visibility
 
 A queued response includes a stable queue ID and queryable status. The customer-facing response must not expose the internal simulation revert.
@@ -132,6 +157,14 @@ Post-withdrawal rebalancing is out of scope. It requires a separate strategy and
 | Consider rebalancing later | Deferred. |
 | Propose before implementation | Keep this ADR `Proposed` until the evidence below is reviewed. |
 
+## Open research and owners
+
+- **Benoit — revert classification:** deploy controlled fake vaults to exercise known failures, then repeat the full path on a pinned fork using official deployment addresses. Whitelist the test wallet and receiver before classifying any revert; a gate failure is not a liquidity failure.
+- **Alex — Hypernative/API split:** determine whether Hypernative can observe API-bypassing attempts and safely trigger a bounded unwind. Document custody, deduplication, griefing controls, and which system owns each state transition.
+- **Vault/API — Aave estimate:** define and test an advisory available-liquidity equation. It must account for vault idle, strategy idle, the adapter's aToken claim, actual Aave reserve liquidity, and conditions that can still make `pool.withdraw` revert.
+
+Until these are resolved, simulation remains the only queue-admission authority and the canary covers API-observed requests only.
+
 ## Evidence required before acceptance
 
 A controlled cross-repository test must prove:
@@ -156,8 +189,13 @@ It must also cover:
 - a second illiquid request while one is active;
 - another withdrawal consuming returned EURC;
 - duplicate workers or events and process restart;
-- unavailable protocol authorization or sweep gas; and
-- unsafe sweep/deallocation gas as the position set grows.
+- unavailable protocol authorization or sweep gas;
+- unsafe sweep/deallocation gas as the position set grows;
+- the same liquidity classification against fake vaults and a pinned production fork;
+- a whitelisted fork wallet and receiver, plus negative gate tests;
+- Atlas authorization with a bounded deadline or a tested revocation path;
+- separate wallet-entitlement, per-wallet queued-commitment, and global queue-capacity calculations; and
+- a direct-wallet attempt that bypasses the API, with the documented v1 response.
 
 Record the target chain, source revisions, deployed addresses, roles, gates, decimals, finality policy, and signer custody with the test evidence.
 
@@ -170,8 +208,9 @@ V1 does not guarantee:
 - a still-valid customer transaction after the wait;
 - a completion deadline;
 - fairness beyond one active request;
-- a fixed EURC payout; or
-- unattended protocol operations.
+- a fixed EURC payout;
+- unattended protocol operations; or
+- coverage of withdrawals submitted outside the Byzantine API.
 
 Stop the canary and reconsider contract escrow or signer automation if:
 
@@ -179,8 +218,10 @@ Stop the canary and reconsider contract escrow or signer automation if:
 - more than one concurrent request is needed;
 - re-signing is too frequent;
 - queued value exceeds the approved risk cap;
-- product requires guaranteed reservation or a composable claim; or
-- manual protocol authorization becomes the bottleneck.
+- product requires guaranteed reservation or a composable claim;
+- manual protocol authorization becomes the bottleneck;
+- API-bypassing withdrawal attempts are frequent enough to invalidate the canary; or
+- Hypernative automation cannot meet the approved custody, deduplication, sizing, and grief-resistance constraints.
 
 ## Alternatives
 
@@ -198,15 +239,22 @@ Change this ADR to `Accepted` only after reviewers approve:
 - queue, retry, pending-time, and value limits;
 - curator, allocator/sentinel, and sweep custody;
 - deployment metadata and bpEUR-to-realized-EURC accounting;
-- customer status, destination handoff, Telegram escalation, and stated non-guarantees; and
-- the controlled integration-test evidence and operational owner.
+- customer status, destination handoff, Telegram escalation, and stated non-guarantees;
+- the controlled integration-test evidence and operational owner;
+- the separation between wallet entitlement, per-wallet queued commitment, and global queue capacity;
+- the fake-vault and whitelisted-fork revert-classification evidence;
+- a bounded Atlas deadline or revocation mechanism; and
+- the explicit API-only coverage decision or an approved Hypernative design.
 
 ## References
 
 - [`src/VaultV2.sol`](../../src/VaultV2.sol)
 - [`src/adapters/ByzantineEurVaultAdapter.sol`](../../src/adapters/ByzantineEurVaultAdapter.sol)
 - [`src/adapters/EurVaultPosition.sol`](../../src/adapters/EurVaultPosition.sol)
+- [`src/adapters/AaveStrategy.sol`](../../src/adapters/AaveStrategy.sol)
 - [`Byzantine-Finance/fx-hedge-contract`](https://github.com/Byzantine-Finance/fx-hedge-contract)
 - [`Byzantine-Finance/byzantine-api`](https://github.com/Byzantine-Finance/byzantine-api)
 - [`byzantine-api ADR 0002`](https://github.com/Byzantine-Finance/byzantine-api/blob/dev/docs/adr/0002-standing-integrator-delegated-authority.md)
+- [`Byzantine-Finance/Atlas`](https://github.com/Byzantine-Finance/Atlas/blob/main/src/Atlas.sol)
+- [Byzantine Curator deployment view](https://curator.byzantine.fi/vault/0x2f99e35ea811f3cc230b26dff817604b5d4b6e38?tab=adapters&adapter=0)
 - Internal product discussion, 2026-07-08


### PR DESCRIPTION
## Summary

- add ADR 0001 proposing a bounded backend-first canary for FXH liquidity shortfalls
- preserve the existing liquid withdrawal hot path and defer contract escrow/reservation until evidence requires it
- document the full operational flow: curator unwind, FXH settlement, adapter sweep, authorized parent-vault deallocation, re-simulation, and customer transaction broadcast
- establish explicit non-guarantees, stop conditions, signer boundaries, and Phase 0 evidence
- allow Markdown ADRs under `docs/adr` while continuing to ignore generated docs